### PR TITLE
Remove NumPy and Numba version restrictions

### DIFF
--- a/.cookiecutterrc
+++ b/.cookiecutterrc
@@ -54,7 +54,7 @@ default_context:
     sphinx_doctest: "no"
     sphinx_theme: "sphinx-rtd-theme"
     test_matrix_separate_coverage: "no"
-    version: "0.3.0"
+    version: "0.4.0"
     version_manager: "bump2version"
     website: "https://www.idmod.org"
     year_from: "2023"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ![implementation](https://img.shields.io/pypi/implementation/laser-core.svg)
 ![license](https://img.shields.io/pypi/l/laser-core.svg)
 
-![commits since v0.3.0](https://img.shields.io/github/commits-since/InstituteforDiseaseModeling/laser/v0.3.0.svg)
+![commits since v0.4.0](https://img.shields.io/github/commits-since/InstituteforDiseaseModeling/laser/v0.4.0.svg)
 
 ## Getting Started
 

--- a/README.rst
+++ b/README.rst
@@ -43,9 +43,9 @@ Overview
     :alt: Supported implementations
     :target: https://pypi.org/project/laser-core/
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/InstituteforDiseaseModeling/laser/v0.3.0.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/InstituteforDiseaseModeling/laser/v0.4.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/InstituteforDiseaseModeling/laser/compare/v0.3.0...main
+    :target: https://github.com/InstituteforDiseaseModeling/laser/compare/v0.4.0...main
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ project = "LASER"
 year = "2023-2024"
 author = "Institute for Disease Modeling"
 copyright = f"{year}, {author}"
-version = release = "0.3.0"
+version = release = "0.4.0"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = "Core functionality for the Light Agent Spatial modeling for ERadication toolkit (LASER)."
 readme = "README.rst"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 keywords = ["spatial modeling", "disease eradication", "agent-based modeling"]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -31,8 +31,8 @@ classifiers = [
 ]
 dependencies = [
     "click",  # ==8.1.7",
-    "numpy>=1.26.4,<2.0.0",
-    "numba~=0.59.1",
+    "numpy",
+    "numba",
     "matplotlib",
     "pandas",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "laser-core"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
   { name="Christopher Lorton", email="christopher.lorton@gatesfoundation.org" },
   { name="Jonathan Bloedow", email="jonathan.bloedow@gatesfoundation.org" },
@@ -127,7 +127,7 @@ packages = ["laser_core"]
 "tests" = ["data/*.csv"]
 
 [tool.bumpversion]
-current_version = "0.3.0"
+current_version = "0.4.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/src/laser_core/__init__.py
+++ b/src/laser_core/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 from .laserframe import LaserFrame
 from .propertyset import PropertySet


### PR DESCRIPTION
Numba seems happy with NumPy >= 2.0 now, so we should not arbitrarily restrict the versions.

This was also complicating using GitHub Codespaces because they had the latest NumPy (>= 2.0) installed.
