### PR TITLE
🐛 fix overflow in migration matrix calculations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ test = [
     "pytest>=6.0",
     "pytest-cov",
     "scipy",
+    "uv",
 ]
 
 [project.urls]

--- a/src/laser_core/migration.py
+++ b/src/laser_core/migration.py
@@ -106,8 +106,11 @@ def gravity(pops: np.ndarray, distances: np.ndarray, k: float, a: float, b: floa
     # Ensure pops and distances are valid
     _sanity_checks(pops, distances, a=a, b=b, c=c, k=k)
 
+    # Promote pops to a robust datatype (e.g., int32 is likely to overflow)
+    pops = pops.astype(np.float64)
+
     # Prevent division by zero by setting diagonal to 1
-    distances1 = distances.copy()
+    distances1 = distances.copy().astype(np.float64)
     np.fill_diagonal(distances1, 1)
 
     # Compute the gravity model network
@@ -195,9 +198,12 @@ def competing_destinations(pops, distances, k, a, b, c, delta, **params):
     # Sanity checks
     _sanity_checks(pops, distances, a=a, k=k, b=b, c=c, delta=delta)
 
+    # Promote pops to a robust datatype (e.g., int32 is likely to overflow)
+    pops = pops.astype(np.float64)
+
     network = gravity(pops, distances, k=k, a=a, b=b, c=c, **params)
     # Construct the p_j^b / d_jk^c matrix, inside the sum
-    distances1 = distances.copy()
+    distances1 = distances.copy().astype(np.float64)
     np.fill_diagonal(distances1, 1)  # Prevent division by zero in `distances ** (-1 * c)`
     competition_matrix = pops**b * distances1 ** (-1 * c)
 
@@ -294,6 +300,10 @@ def stouffer(pops, distances, k, a, b, include_home, **params):
     # Sanity checks
     _sanity_checks(pops, distances, a=a, b=b, k=k, include_home=include_home)
 
+    # Promote pops and distances to a robust datatype (e.g., int32 is likely to overflow)
+    pops = pops.astype(np.float64)
+    distances = distances.astype(np.float64)
+
     # We will just use the "truthiness" of include_home (could be boolean, could be 0/1)
 
     network = np.zeros_like(distances)
@@ -361,6 +371,10 @@ def radiation(pops, distances, k, include_home, **params):
 
     # Sanity checks
     _sanity_checks(pops, distances, k=k, include_home=include_home)
+
+    # Promote pops and distances to a robust datatype (e.g., int32 is likely to overflow)
+    pops = pops.astype(np.float64)
+    distances = distances.astype(np.float64)
 
     # We will just use the "truthiness" of include_home (could be boolean, could be 0/1)
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -737,5 +737,42 @@ class TestMigrationFunctionSanityChecks(unittest.TestCase):
         return
 
 
+class TestsForOverflow(unittest.TestCase):
+    pops = np.array([99510, 595855, 263884], dtype=np.int32)
+    dist = np.array([[0, 4, 66], [4, 0, 827], [66, 827, 0]], dtype=np.int32)
+    k = 3000
+    a = 1
+    b = 1
+    c = 2.0
+
+    def test_gravity(self):
+        g = gravity(self.pops, self.dist, self.k, self.a, self.b, self.c)
+        assert np.all(g >= 0), "Gravity calculation should not overflow and/or return negative values."
+
+        return
+
+    def test_competing_destinations(self):
+        cd = competing_destinations(self.pops, self.dist, self.k, self.a, self.b, self.c, delta=1.1)
+        assert np.all(cd >= 0), "Competing destinations calculation should not overflow and/or return negative values."
+
+        return
+
+    def test_stouffer(self):
+        s = stouffer(self.pops, self.dist, self.k, self.a, self.b, include_home=False)
+        assert np.all(s >= 0), "Stouffer migration calculation (include_home=False) should not overflow and/or return negative values."
+        s = stouffer(self.pops, self.dist, self.k, self.a, self.b, include_home=True)
+        assert np.all(s >= 0), "Stouffer migration calculation (include_home=True) should not overflow and/or return negative values."
+
+        return
+
+    def test_radiation(self):
+        r = radiation(self.pops, self.dist, self.k, include_home=False)
+        assert np.all(r >= 0), "Radiation migration calculation (include_home=False) should not overflow and/or return negative values."
+        r = radiation(self.pops, self.dist, self.k, include_home=True)
+        assert np.all(r >= 0), "Radiation migration calculation (include_home=True) should not overflow and/or return negative values."
+
+        return
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If populations come in as `np.int32` there can be overflow leading to negative network connectivity values.
Fixes #134 