### PR TITLE
✨ update row_normalizer() to return float32

### DIFF
--- a/src/laser_core/migration.py
+++ b/src/laser_core/migration.py
@@ -143,7 +143,7 @@ def row_normalizer(network, max_rowsum):
     _is_instance(max_rowsum, Number, f"max_rowsum must be a numeric value ({type(max_rowsum)=})")
     _has_values(0 <= max_rowsum <= 1, "max_rowsum must be in [0, 1]")
 
-    # Promote to network to floating point
+    # Promote network to floating point
     # If the incoming network is an integer type and max_rowsum is < 1.0, the result is all zeros.
     network = network.copy().astype(np.float32)
 

--- a/src/laser_core/migration.py
+++ b/src/laser_core/migration.py
@@ -143,6 +143,10 @@ def row_normalizer(network, max_rowsum):
     _is_instance(max_rowsum, Number, f"max_rowsum must be a numeric value ({type(max_rowsum)=})")
     _has_values(0 <= max_rowsum <= 1, "max_rowsum must be in [0, 1]")
 
+    # Promote to network to floating point
+    # If the incoming network is an integer type and max_rowsum is < 1.0, the result is all zeros.
+    network = network.copy().astype(np.float32)
+
     rowsums = network.sum(axis=1)
     rows_to_renorm = rowsums > max_rowsum
     network[rows_to_renorm] = network[rows_to_renorm] * max_rowsum / rowsums[rows_to_renorm, np.newaxis]

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -104,13 +104,30 @@ class TestMigrationFunctions(unittest.TestCase):
 
         network = np.array([[0.0, 0.01, 0.02, 0.03], [0.05, 0.0, 0.05, 0.1], [0.2, 0.2, 0.0, 0.6], [0.001, 0.002, 0.003, 0.0]])
         max_rowsum = 0.1
-        test_network = np.array([[0.0, 0.01, 0.02, 0.03], [0.025, 0.0, 0.025, 0.05], [0.02, 0.02, 0.0, 0.06], [0.001, 0.002, 0.003, 0.0]])
-        network = row_normalizer(network, max_rowsum)
-        for i in range(network.shape[0]):  # check 10 random values
-            for j in range(network.shape[1]):
-                assert np.isclose(
-                    network[i, j], test_network[i, j]
-                ), f"network[{i}, {j}] = {network[i, j]}, expected test_network[{i}, {j}]={test_network[i, j]}"
+        expected = np.array([[0.0, 0.01, 0.02, 0.03], [0.025, 0.0, 0.025, 0.05], [0.02, 0.02, 0.0, 0.06], [0.001, 0.002, 0.003, 0.0]])
+        normalized = row_normalizer(network, max_rowsum)
+        assert np.all(np.isclose(normalized, expected)), (
+            "mismatch(es): \n\t"
+            + "\n\t".join(str((idx, normalized[idx], expected[idx])) for idx in zip(*np.where(~np.isclose(normalized, expected)))),
+        )
+
+        return
+
+    def test_row_normalizer_with_integer_values(self):
+        """Test that the row normalizer returns useful values when the input network is a integer data type and the max rowsum is fractional."""
+
+        network = np.array([[0.0, 0.01, 0.02, 0.03], [0.05, 0.0, 0.05, 0.1], [0.2, 0.2, 0.0, 0.6], [0.001, 0.002, 0.003, 0.0]])
+        network *= 1000
+        network = network.astype(np.int32)
+        max_rowsum = 0.1
+        expected = np.array(
+            [[0.0, 1 / 60, 2 / 60, 3 / 60], [0.025, 0.0, 0.025, 0.05], [0.02, 0.02, 0.0, 0.06], [1 / 60, 2 / 60, 3 / 60, 0.0]]
+        )
+        normalized = row_normalizer(network, max_rowsum)
+        assert np.all(np.isclose(normalized, expected)), (
+            "mismatch(es): \n\t"
+            + "\n\t".join(str((idx, normalized[idx], expected[idx])) for idx in zip(*np.where(~np.isclose(normalized, expected)))),
+        )
 
         return
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -114,7 +114,7 @@ class TestMigrationFunctions(unittest.TestCase):
         return
 
     def test_row_normalizer_with_integer_values(self):
-        """Test that the row normalizer returns useful values when the input network is a integer data type and the max rowsum is fractional."""
+        """Test that the row normalizer returns useful values when the input network is an integer data type and the max rowsum is fractional."""
 
         network = np.array([[0.0, 0.01, 0.02, 0.03], [0.05, 0.0, 0.05, 0.1], [0.2, 0.2, 0.0, 0.6], [0.001, 0.002, 0.003, 0.0]])
         network *= 1000


### PR DESCRIPTION
If the incoming network is an integer type and the max rowsum is fractional (common), the returned values would be zero.
Fixes #136 