### PR TITLE
Add save_snapshot and load_snapshot

### DIFF
--- a/docs/eula.rst
+++ b/docs/eula.rst
@@ -8,7 +8,7 @@ In many cases -— particularly during model calibration -— it is far more eff
 population once, save it, and then reload the initialized state for subsequent runs.
 
 
-This approach is especially useful when working with EULAs -- **E**pidemiologically **U**ninteresting **L**ight **A**gents. For example it can be a very powerful optimization to compress all the agents who are already (permanently) recovered or immune in a measles or polio model into a number/bucket. In such models, the majority of the initial population may be in the "Recovered" state, potentially comprising 90% or more of all agents. If you are simulating 100 million agents, storing all of them can result in punitive memory usage.
+This approach is especially useful when working with EULAs -- Epidemiologically Uninteresting Light Agents. For example it can be a very powerful optimization to compress all the agents who are already (permanently) recovered or immune in a measles or polio model into a number/bucket. In such models, the majority of the initial population may be in the "Recovered" state, potentially comprising 90% or more of all agents. If you are simulating 100 million agents, storing all of them can result in punitive memory usage.
 
 
 To address this, LASER supports a **squashing** process. Squashing involves

--- a/docs/eula.rst
+++ b/docs/eula.rst
@@ -93,8 +93,19 @@ Implement a ``load(path)`` class method:
   - Results matrix
   - Parameters
 
-- Set ``.capacity = .count`` to drop excess memory allocation
+- Set ``.capacity = .count`` if not doing births, else set capacity based on projected population growth from count.
 - Reconstruct all components using ``init_from_file()``
+
+.. warning::
+
+   **Vital Dynamics Considerations**
+
+   When modeling vital dynamics—especially births—there is an additional step to ensure consistency after loading:
+
+   - **Property initialization for unborn individuals** must be repeated if your model pre-assigns properties up to ``.capacity``. For example, if timers or demographic attributes (like ``date_of_birth``) are pre-initialized at ``t=0``, you must ensure this initialization is re-applied after loading, because only the ``.count`` population is reloaded, not the future ``.capacity``.
+
+   Failing to do so may result in improperly initialized agents being birthed after the snapshot load, which can lead to subtle or catastrophic model errors.
+
 
 4. Preserve EULA’d Results
 --------------------------

--- a/docs/eula.rst
+++ b/docs/eula.rst
@@ -1,0 +1,192 @@
+Population Initialization, Squashing, and Snapshot Management in LASER
+=======================================================================
+
+
+As population models in LASER grow to very large sizes, it becomes computationally expensive
+to repeatedly run sophisticated initialization routines. In many cases—particularly during
+model calibration—it is far more efficient to initialize the population once, save it, and
+then reload the initialized state for subsequent runs.
+
+
+This approach is especially useful when working with *lightweight agents* that are
+epidemiologically uninteresting—for example, agents who are already recovered or immune
+in a measles or polio model. In such models, the majority of the initial population may be
+in the "Recovered" state, potentially comprising 90% or more of all agents. If you are
+simulating 100 million agents, storing all of them can result in excessive memory usage.
+
+
+To address this, LASER supports a **squashing** process. Squashing involves
+*defragmenting the data frame* such that all epidemiologically active or "interesting" agents
+(e.g., Susceptible or Infectious) are moved to the beginning of the array or table, and
+less relevant agents (e.g., Recovered) are moved to the end.
+
+
+Following squashing:
+
+- The population count is adjusted so that all `for` loops and step functions iterate
+  **only over the active population**.
+- This not only reduces memory usage but also improves performance by avoiding unnecessary
+  computation over inactive agents.
+
+Furthermore, when saving a **Snapshot**, only the active (unsquashed) portion of the
+population is saved. Upon reloading:
+
+- Only this subset is allocated in memory.
+- This prevents the performance penalty of managing large volumes of unused agent data.
+
+Important Detail
+----------------
+
+Before squashing, LASER allows you to **count and record** the number of recovered
+(or otherwise squashed) agents. This count should be stored in a summary variable—
+typically the ``R`` column of the results data frame. This ensures your model retains a
+complete epidemiological record even though the agents themselves are no longer instantiated.
+
+
+Example
+-------
+
+A working example is provided in the documentation: a simple spatial SIR model demonstrating
+how to perform population squashing, save a snapshot, and reload it properly. This example
+illustrates how to:
+
+- Initialize the full population.
+- Squash and record unneeded agents.
+- Save only the active subset.
+- Reload efficiently for future simulations.
+
+
+RecoveredSquashModel Example
+============================
+
+This example demonstrates a simple multi-node SIR model using the LASER framework, including:
+
+- Disease transmission and progression
+- Population squashing to remove recovered agents
+- Snapshot save/load functionality
+- Time series result plotting
+
+.. code-block:: python
+
+    import numpy as np
+    import click
+    import matplotlib.pyplot as plt
+    from pathlib import Path
+
+    from laser_core import LaserFrame, PropertySet
+
+    class Transmission:
+        """
+        A simple transmission component that spreads infection within each node.
+        """
+        def __init__(self, population, pars):
+            self.population = population
+            self.pars = pars
+
+        def step(self):
+            susceptible = self.population.disease_state == 0
+            infected = self.population.disease_state == 1
+            inf_node_ids = self.population.node_id[infected]
+            node_counts = np.bincount(inf_node_ids, minlength=self.population.node_id.max() + 1)
+
+            for nid in range(len(node_counts)):
+                if node_counts[nid] > 0:
+                    sus_idx = (self.population.node_id == nid) & susceptible
+                    new_inf = np.random.rand(sus_idx.sum()) < self.pars.transmission_prob
+                    indices = np.where(sus_idx)[0][new_inf]
+                    self.population.disease_state[indices] = 1
+
+        @classmethod
+        def init_from_file(cls, population, pars):
+            return cls(population, pars)
+
+    class Progression:
+        """
+        A simple progression component that recovers infected individuals probabilistically.
+        """
+        def __init__(self, population, pars):
+            self.population = population
+            self.pars = pars
+
+        def step(self):
+            infected = self.population.disease_state == 1
+            recoveries = np.random.rand(infected.sum()) < (1 / self.pars.recovery_days)
+            self.population.disease_state[np.where(infected)[0][recoveries]] = 2
+
+        @classmethod
+        def init_from_file(cls, population, pars):
+            return cls(population, pars)
+
+    class RecoveredSquashModel:
+        """
+        A simple multi-node SIR model demonstrating use of LASER's squash and snapshot mechanisms.
+        """
+        def __init__(self, num_agents=100000, num_nodes=20, timesteps=365):
+            ...
+            self.components = [
+                Transmission(self.population, self.pars),
+                Progression(self.population, self.pars)
+            ]
+
+        def initialize(self):
+            ...
+
+        def seed_infections(self):
+            ...
+
+        def squash_recovered(self):
+            """
+            Removes all agents who are recovered (state 2).
+            This reduces memory footprint and speeds up simulation.
+            """
+            ...
+
+        def populate_results(self):
+            """
+            Populate initial R values before squashing to reflect the pre-squash immunity landscape.
+            """
+            ...
+
+        def run(self):
+            ...
+
+        def save(self, path):
+            """
+            Save the current model state to an HDF5 file, including population frame,
+            pre-squash results, and simulation parameters.
+            """
+            ...
+
+        @classmethod
+        def load(cls, path):
+            """
+            Reload a model from an HDF5 snapshot. Note: reloaded population will have
+            only post-squash agents (e.g., susceptibles and infected).
+            """
+            ...
+
+        def plot(self):
+            """
+            Plot the time series of total S, I, and R across all nodes.
+            """
+            ...
+
+    @click.command()
+    @click.option("--init-pop-file", type=click.Path(), default=None, help="Path to snapshot to resume from.")
+    @click.option("--output", type=click.Path(), default="model_output.h5")
+    def main(init_pop_file, output):
+        if init_pop_file:
+            model = RecoveredSquashModel.load(init_pop_file)
+            model.run()
+            model.plot()
+        else:
+            model = RecoveredSquashModel()
+            model.initialize()
+            model.seed_infections()
+            model.populate_results()
+            model.squash_recovered()
+            model.save(output)
+            print(f"Initial population saved to {output}")
+
+    if __name__ == "__main__":
+        main()

--- a/docs/eula.rst
+++ b/docs/eula.rst
@@ -8,12 +8,7 @@ In many cases -— particularly during model calibration -— it is far more eff
 population once, save it, and then reload the initialized state for subsequent runs.
 
 
-This approach is especially useful when working with EULAs -- **E**pidemiologically **U**ninteresting
-**L**ight **A**gents. For example it can be a very powerful optimization to compress all the agents who
-are already (permanently) recovered or immune in a measles or polio model into a number/bucket. In
-such models, the majority of the initial population may be in the "Recovered" state, potentially
-comprising 90% or more of all agents. If you are simulating 100 million agents, storing all of them
-can result in punitive memory usage.
+This approach is especially useful when working with EULAs -- **E**pidemiologically **U**ninteresting **L**ight **A**gents. For example it can be a very powerful optimization to compress all the agents who are already (permanently) recovered or immune in a measles or polio model into a number/bucket. In such models, the majority of the initial population may be in the "Recovered" state, potentially comprising 90% or more of all agents. If you are simulating 100 million agents, storing all of them can result in punitive memory usage.
 
 
 To address this, LASER supports a **squashing** process. Squashing involves
@@ -31,8 +26,7 @@ Some notes about squashing:
 
 Some caveats about using saved populations:
 - You will want to be confident that the saved population is sufficiently randomized and representative;
-- If you are calibrating parameters used to create the initial population in the first place, you'll need
-  to recreate those parts of the population after loading, diminishing the benefit of the save/load approach.
+- If you are calibrating parameters used to create the initial population in the first place, you'll need to recreate those parts of the population after loading, diminishing the benefit of the save/load approach.
 
 
 When saving a **Snapshot**, note that only the active (unsquashed) portion of the

--- a/docs/eula.rst
+++ b/docs/eula.rst
@@ -8,8 +8,8 @@ In many cases -— particularly during model calibration -— it is far more eff
 population once, save it, and then reload the initialized state for subsequent runs.
 
 
-This approach is especially useful when working with EULAs -- *E*pidemiologically *U*ninteresting 
-*L*ight *A*gents. For example it can be a very powerful optimization to compress all the agents who 
+This approach is especially useful when working with EULAs -- **E**pidemiologically **U**ninteresting 
+**L**ight **A**gents. For example it can be a very powerful optimization to compress all the agents who 
 are already (permanently) recovered or immune in a measles or polio model into a number/bucket. In 
 such models, the majority of the initial population may be in the "Recovered" state, potentially 
 comprising 90% or more of all agents. If you are simulating 100 million agents, storing all of them 

--- a/docs/eula.rst
+++ b/docs/eula.rst
@@ -42,29 +42,76 @@ Before squashing, LASER allows you to **count and record** the number of recover
 typically the ``R`` column of the results data frame. This ensures your model retains a
 complete epidemiological record even though the agents themselves are no longer instantiated.
 
+Implementation Deatils: How to Add Squashing, Saving, Loading, and Correct R Tracking to a LASER SIR Model
+==========================================================================================================
 
-Example
--------
+1. Add Squashing
+----------------
 
-A working example is provided in the documentation: a simple spatial SIR model demonstrating
-how to perform population squashing, save a snapshot, and reload it properly. This example
-illustrates how to:
+- **Add a `squash_recovered()` function**  
+  This should call `LaserFrame.squash(...)` with a boolean mask that excludes recovered agents (`disease_state == 2`). You may choose a different criterion, such as age-based squashing.
 
-- Initialize the full population.
-- Squash and record unneeded agents.
-- Save only the active subset.
-- Reload efficiently for future simulations.
+- **Count your “squashed away” agents first**  
+  You must compute and store all statistics related to agents being squashed *before* the `squash()` call. After squashing, only the left-hand portion of the arrays (up to `.count`) remains valid.
 
+- **Seed infections after squashing**  
+  If your model seeds new infections (`disease_state == 1`), this must happen *after* squashing. Otherwise, infected agents may be inadvertently removed.
 
-RecoveredSquashModel Example
-============================
+- **Store the squashed-away totals by node**  
+  Before squashing, compute and record node-wise totals (e.g., recovered counts) in `results.R[0, :]` so this pre-squash information persists.
 
-This example demonstrates a simple multi-node SIR model using the LASER framework, including:
+- **Optionally simulate EULA effects once and save**  
+  If modeling aging or death among squashed agents, simulate this up front and store the full `[time, node]` matrix (e.g., `results.R[:, :]`). This avoids recomputation at runtime.
 
-- Disease transmission and progression
-- Population squashing to remove recovered agents
-- Snapshot save/load functionality
-- Time series result plotting
+2. Save Function
+----------------
+
+Implement a ``save(path)`` method:
+
+- Use ``LaserFrame.save_snapshot(path, results_r=..., pars=...)``
+- Include:
+  
+  - The squashed population (active agents only)
+  - The ``results.R`` matrix containing both pre-squash and live simulation values
+  - The full parameter set in a ``PropertySet``
+
+3. Load Function
+----------------
+
+Implement a ``load(path)`` class method:
+
+- Call ``LaserFrame.load_snapshot(path)`` to retrieve:
+  
+  - Population frame
+  - Results matrix
+  - Parameters
+
+- Set ``.capacity = .count`` to drop excess memory allocation
+- Reconstruct all components using ``init_from_file()``
+
+4. Preserve EULA’d Results
+--------------------------
+
+- **Use ``+=`` to track new recoveries alongside pre-squash R values**  
+  In ``run()``, use additive updates so that pre-saved recovered agents are preserved:
+
+  .. code-block:: python
+
+      self.results.R[t, nid] += ((self.population.node_id == nid) & 
+                                 (self.population.disease_state == 2)).sum()
+
+This ensures your output accounts for both squashed-away immunity and recoveries during the live simulation.
+
+Complete SIR LASER Model with Squashing and Snapshot Support
+============================================================
+
+This example demonstrates a complete SIR model using LASER, featuring:
+
+- Agent squashing based on recovery state
+- Pre-squash result capture
+- Snapshot saving and loading
+- Node-level time series tracking
+- Plotting of total S, I, and R dynamics
 
 .. code-block:: python
 
@@ -122,40 +169,77 @@ This example demonstrates a simple multi-node SIR model using the LASER framewor
         A simple multi-node SIR model demonstrating use of LASER's squash and snapshot mechanisms.
         """
         def __init__(self, num_agents=100000, num_nodes=20, timesteps=365):
-            ...
+            self.num_agents = num_agents
+            self.num_nodes = num_nodes
+            self.timesteps = timesteps
+            self.population = LaserFrame(capacity=num_agents, initial_count=num_agents)
+            self.population.add_scalar_property("node_id", dtype=np.int32)
+            self.population.add_scalar_property("disease_state", dtype=np.int8)  # 0=S, 1=I, 2=R
+
+            self.results = LaserFrame(capacity=self.num_nodes)
+            self.results.add_vector_property("S", length=timesteps, dtype=np.int32)
+            self.results.add_vector_property("I", length=timesteps, dtype=np.int32)
+            self.results.add_vector_property("R", length=timesteps, dtype=np.int32)
+
+            self.pars = PropertySet({
+                "r0": 2.5,
+                "migration_k": 0.1,
+                "seasonal_factor": 0.8,
+                "transmission_prob": 0.2,
+                "recovery_days": 14
+            })
+
             self.components = [
                 Transmission(self.population, self.pars),
                 Progression(self.population, self.pars)
             ]
 
         def initialize(self):
-            ...
+            np.random.seed(42)
+            self.population.node_id[:] = np.random.randint(0, self.num_nodes, size=self.num_agents)
+            recovered = np.random.rand(self.num_agents) < 0.6
+            self.population.disease_state[:] = np.where(recovered, 2, 0)
 
         def seed_infections(self):
-            ...
+            susceptible = self.population.disease_state == 0
+            num_seed = max(1, int(0.001 * self.population.count))
+            seed_indices = np.random.choice(np.where(susceptible)[0], size=num_seed, replace=False)
+            self.population.disease_state[seed_indices] = 1
 
         def squash_recovered(self):
             """
             Removes all agents who are recovered (state 2).
             This reduces memory footprint and speeds up simulation.
             """
-            ...
+            keep = self.population.disease_state[:self.population.count] != 2
+            self.population.squash(keep)
 
         def populate_results(self):
             """
             Populate initial R values before squashing to reflect the pre-squash immunity landscape.
             """
-            ...
+            for nid in range(self.num_nodes):
+                initial_r = ((self.population.disease_state == 2) & (self.population.node_id == nid)).sum()
+                decay = np.linspace(initial_r, initial_r * 0.9, self.timesteps, dtype=int)
+                self.results.R[:, nid] = decay
+            print("Initial R counts per node:", self.results.R[0, :])
+            print("Total initial R (summed):", self.results.R[0, :].sum())
 
         def run(self):
-            ...
+            for t in range(self.timesteps):
+                for component in self.components:
+                    component.step()
+                for nid in range(self.num_nodes):
+                    self.results.S[t, nid] = ((self.population.node_id == nid) & (self.population.disease_state == 0)).sum()
+                    self.results.I[t, nid] = ((self.population.node_id == nid) & (self.population.disease_state == 1)).sum()
+                    self.results.R[t, nid] += ((self.population.node_id == nid) & (self.population.disease_state == 2)).sum()
 
         def save(self, path):
             """
             Save the current model state to an HDF5 file, including population frame,
             pre-squash results, and simulation parameters.
             """
-            ...
+            self.population.save_snapshot(path, results_r=self.results.R, pars=self.pars)
 
         @classmethod
         def load(cls, path):
@@ -163,13 +247,39 @@ This example demonstrates a simple multi-node SIR model using the LASER framewor
             Reload a model from an HDF5 snapshot. Note: reloaded population will have
             only post-squash agents (e.g., susceptibles and infected).
             """
-            ...
+            pop, results_r, pars = LaserFrame.load_snapshot(path)
+            model = cls(num_agents=pop.capacity, num_nodes=results_r.shape[1], timesteps=results_r.shape[0])
+            model.population = pop
+            model.results.R[:, :] = results_r
+            model.pars = PropertySet(pars)
+            model.pars["transmission_prob"] /= 10  # example modification after reload
+            model.components = [
+                Transmission.init_from_file(model.population, model.pars),
+                Progression.init_from_file(model.population, model.pars)
+            ]
+            return model
 
         def plot(self):
             """
             Plot the time series of total S, I, and R across all nodes.
             """
-            ...
+            plt.figure(figsize=(10, 6))
+            s_total = self.results.S.sum(axis=1)
+            i_total = self.results.I.sum(axis=1)
+            r_total = self.results.R.sum(axis=1)
+            plt.plot(s_total, label="Susceptible")
+            plt.plot(i_total, label="Infected")
+            plt.plot(r_total, label="Recovered")
+
+            plt.xlabel("Time")
+            plt.ylabel("Population count")
+            plt.title("SIR Model Over Time")
+            plt.legend()
+            plt.grid(True)
+            plt.tight_layout()
+            plt.savefig("sir_plot.png")
+            plt.show()
+            print("Plot saved as sir_plot.png")
 
     @click.command()
     @click.option("--init-pop-file", type=click.Path(), default=None, help="Path to snapshot to resume from.")

--- a/docs/eula.rst
+++ b/docs/eula.rst
@@ -2,26 +2,28 @@ Population Initialization, Squashing, and Snapshot Management in LASER
 =======================================================================
 
 
-As population models in LASER grow to very large sizes, it becomes computationally expensive
-to repeatedly run sophisticated initialization routines. In many cases—particularly during
-model calibration—it is far more efficient to initialize the population once, save it, and
-then reload the initialized state for subsequent runs.
+As the number agents in your LASER population model grows (e.g., 1e8), it can become computationally 
+expensive and unnecessary to repeatedly run the same (sophisticated) initialization routine every sim. 
+In many cases -— particularly during model calibration -— it is far more efficient to initialize the 
+population once, save it, and then reload the initialized state for subsequent runs.
 
 
-This approach is especially useful when working with *lightweight agents* that are
-epidemiologically uninteresting—for example, agents who are already recovered or immune
-in a measles or polio model. In such models, the majority of the initial population may be
-in the "Recovered" state, potentially comprising 90% or more of all agents. If you are
-simulating 100 million agents, storing all of them can result in excessive memory usage.
+This approach is especially useful when working with EULAs -- *E*pidemiologically *U*ninteresting 
+*L*ight *A*gents. For example it can be a very powerful optimization to compress all the agents who 
+are already (permanently) recovered or immune in a measles or polio model into a number/bucket. In 
+such models, the majority of the initial population may be in the "Recovered" state, potentially 
+comprising 90% or more of all agents. If you are simulating 100 million agents, storing all of them 
+can result in punitive memory usage.
 
 
 To address this, LASER supports a **squashing** process. Squashing involves
 *defragmenting the data frame* such that all epidemiologically active or "interesting" agents
 (e.g., Susceptible or Infectious) are moved to the beginning of the array or table, and
-less relevant agents (e.g., Recovered) are moved to the end.
+less relevant agents (e.g., Recovered) are moved to the end. Though please note that you should
+never assume that the squashed agents are preserved.
 
 
-Following squashing:
+Some notes about squashing:
 
 - The population count is adjusted so that all `for` loops and step functions iterate
   **only over the active population**.
@@ -37,10 +39,10 @@ population is saved. Upon reloading:
 Important Detail
 ----------------
 
-Before squashing, LASER allows you to **count and record** the number of recovered
-(or otherwise squashed) agents. This count should be stored in a summary variable—
-typically the ``R`` column of the results data frame. This ensures your model retains a
-complete epidemiological record even though the agents themselves are no longer instantiated.
+Before squashing, you should **count and record** the number of recovered (or otherwise squashed) agents. 
+This count should be stored in a summary variable —- typically the ``R`` column of the results data frame. 
+This ensures your model retains a complete epidemiological record even though the agents themselves are 
+no longer instantiated.
 
 Implementation Deatils: How to Add Squashing, Saving, Loading, and Correct R Tracking to a LASER SIR Model
 ==========================================================================================================

--- a/docs/eula.rst
+++ b/docs/eula.rst
@@ -2,17 +2,17 @@ Population Initialization, Squashing, and Snapshot Management in LASER
 =======================================================================
 
 
-As the number agents in your LASER population model grows (e.g., 1e8), it can become computationally 
-expensive and unnecessary to repeatedly run the same (sophisticated) initialization routine every sim. 
-In many cases -— particularly during model calibration -— it is far more efficient to initialize the 
+As the number agents in your LASER population model grows (e.g., 1e8), it can become computationally
+expensive and unnecessary to repeatedly run the same (sophisticated) initialization routine every sim.
+In many cases -— particularly during model calibration -— it is far more efficient to initialize the
 population once, save it, and then reload the initialized state for subsequent runs.
 
 
-This approach is especially useful when working with EULAs -- **E**pidemiologically **U**ninteresting 
-**L**ight **A**gents. For example it can be a very powerful optimization to compress all the agents who 
-are already (permanently) recovered or immune in a measles or polio model into a number/bucket. In 
-such models, the majority of the initial population may be in the "Recovered" state, potentially 
-comprising 90% or more of all agents. If you are simulating 100 million agents, storing all of them 
+This approach is especially useful when working with EULAs -- **E**pidemiologically **U**ninteresting
+**L**ight **A**gents. For example it can be a very powerful optimization to compress all the agents who
+are already (permanently) recovered or immune in a measles or polio model into a number/bucket. In
+such models, the majority of the initial population may be in the "Recovered" state, potentially
+comprising 90% or more of all agents. If you are simulating 100 million agents, storing all of them
 can result in punitive memory usage.
 
 
@@ -39,9 +39,9 @@ population is saved. Upon reloading:
 Important Detail
 ----------------
 
-Before squashing, you should **count and record** the number of recovered (or otherwise squashed) agents. 
-This count should be stored in a summary variable —- typically the ``R`` column of the results data frame. 
-This ensures your model retains a complete epidemiological record even though the agents themselves are 
+Before squashing, you should **count and record** the number of recovered (or otherwise squashed) agents.
+This count should be stored in a summary variable —- typically the ``R`` column of the results data frame.
+This ensures your model retains a complete epidemiological record even though the agents themselves are
 no longer instantiated.
 
 Implementation Deatils: How to Add Squashing, Saving, Loading, and Correct R Tracking to a LASER SIR Model
@@ -50,19 +50,19 @@ Implementation Deatils: How to Add Squashing, Saving, Loading, and Correct R Tra
 1. Add Squashing
 ----------------
 
-- **Add a `squash_recovered()` function**  
+- **Add a `squash_recovered()` function**
   This should call `LaserFrame.squash(...)` with a boolean mask that excludes recovered agents (`disease_state == 2`). You may choose a different criterion, such as age-based squashing.
 
-- **Count your “squashed away” agents first**  
+- **Count your “squashed away” agents first**
   You must compute and store all statistics related to agents being squashed *before* the `squash()` call. After squashing, only the left-hand portion of the arrays (up to `.count`) remains valid.
 
-- **Seed infections after squashing**  
+- **Seed infections after squashing**
   If your model seeds new infections (`disease_state == 1`), this must happen *after* squashing. Otherwise, infected agents may be inadvertently removed.
 
-- **Store the squashed-away totals by node**  
+- **Store the squashed-away totals by node**
   Before squashing, compute and record node-wise totals (e.g., recovered counts) in `results.R[0, :]` so this pre-squash information persists.
 
-- **Optionally simulate EULA effects once and save**  
+- **Optionally simulate EULA effects once and save**
   If modeling aging or death among squashed agents, simulate this up front and store the full `[time, node]` matrix (e.g., `results.R[:, :]`). This avoids recomputation at runtime.
 
 2. Save Function
@@ -72,7 +72,7 @@ Implement a ``save(path)`` method:
 
 - Use ``LaserFrame.save_snapshot(path, results_r=..., pars=...)``
 - Include:
-  
+
   - The squashed population (active agents only)
   - The ``results.R`` matrix containing both pre-squash and live simulation values
   - The full parameter set in a ``PropertySet``
@@ -83,7 +83,7 @@ Implement a ``save(path)`` method:
 Implement a ``load(path)`` class method:
 
 - Call ``LaserFrame.load_snapshot(path)`` to retrieve:
-  
+
   - Population frame
   - Results matrix
   - Parameters
@@ -94,12 +94,12 @@ Implement a ``load(path)`` class method:
 4. Preserve EULA’d Results
 --------------------------
 
-- **Use ``+=`` to track new recoveries alongside pre-squash R values**  
+- **Use ``+=`` to track new recoveries alongside pre-squash R values**
   In ``run()``, use additive updates so that pre-saved recovered agents are preserved:
 
   .. code-block:: python
 
-      self.results.R[t, nid] += ((self.population.node_id == nid) & 
+      self.results.R[t, nid] += ((self.population.node_id == nid) &
                                  (self.population.disease_state == 2)).sum()
 
 This ensures your output accounts for both squashed-away immunity and recoveries during the live simulation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Contents
    example
    vdexample
    spatialexample
+   eula
    performance
    calibration
    contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "numba",
     "matplotlib",
     "pandas",
+    "h5py"
 ]
 
 [project.optional-dependencies]

--- a/src/laser_core/laserframe.py
+++ b/src/laser_core/laserframe.py
@@ -313,10 +313,10 @@ class LaserFrame:
     @classmethod
     def load_snapshot(cls, path):
         """
-        Load a LaserFrameIO and optional extras from an HDF5 snapshot file.
+        Load a LaserFrame and optional extras from an HDF5 snapshot file.
 
         Returns:
-            frame (LaserFrameIO)
+            frame (LaserFrame)
             results_r (np.ndarray or None)
             pars (dict or None)
         """

--- a/src/laser_core/laserframe.py
+++ b/src/laser_core/laserframe.py
@@ -298,7 +298,10 @@ class LaserFrame:
             if not key.startswith("_"):
                 value = getattr(self, key)
                 if isinstance(value, np.ndarray):
-                    group.create_dataset(key, data=value[: self._count])
+                    data = value[: self._count]
+                    group.create_dataset(key, data=data)
+
+
 
     def _save_dict(self, data, group):
         """
@@ -325,12 +328,11 @@ class LaserFrame:
             count = int(group.attrs["count"])
             capacity = int(group.attrs["capacity"])
 
-            frame = cls(capacity=capacity, initial_count=count)
+            frame = cls(capacity=count, initial_count=count)
             for key in group:
                 data = group[key][:]
                 dtype = data.dtype
                 frame.add_scalar_property(name=key, dtype=dtype, default=0)
-                setattr(frame, key, np.zeros(capacity, dtype=dtype))
                 getattr(frame, key)[:count] = data
 
             results_r = f["recovered"][()] if "recovered" in f else None

--- a/src/laser_core/laserframe.py
+++ b/src/laser_core/laserframe.py
@@ -24,6 +24,8 @@ Attributes:
 """
 
 import numpy as np
+import h5py
+#from laser_core import PropertySet
 
 
 class LaserFrame:
@@ -271,6 +273,7 @@ class LaserFrame:
             results_r: Optional 2D numpy array of recovered counts
             pars: Optional PropertySet or dict of parameters
         """
+        from laser_core.propertyset import PropertySet # to avoid circular import
         with h5py.File(path, "w") as f:
             self._save(f, "people")
 
@@ -329,9 +332,20 @@ class LaserFrame:
                 getattr(frame, key)[:count] = data
 
             results_r = f["recovered"][()] if "recovered" in f else None
-            pars = {key: f["pars"][key][()] for key in f["pars"]} if "pars" in f else None
+
             if "pars" in f:
-                pars.update(dict(f["pars"].attrs))
+                pars_group = f["pars"]
+                #pars = {key: pars_group[key][()] for key in pars_group}
+                pars = {
+                    key: (pars_group[key][()].decode() if isinstance(pars_group[key][()], bytes) else pars_group[key][()])
+                    for key in pars_group
+                }
+                pars.update({
+                    key: (val.decode() if isinstance(val, bytes) else val)
+                    for key, val in pars_group.attrs.items()
+                })
+            else:
+                pars = None
 
         return frame, results_r, pars
 

--- a/src/laser_core/laserframe.py
+++ b/src/laser_core/laserframe.py
@@ -262,6 +262,78 @@ class LaserFrame:
 
         return
 
+    def save_snapshot(self, path, results_r=None, pars=None):
+        """
+        Save this LaserFrame and optional extras to an HDF5 snapshot file.
+
+        Parameters:
+            path: Destination file path
+            results_r: Optional 2D numpy array of recovered counts
+            pars: Optional PropertySet or dict of parameters
+        """
+        with h5py.File(path, "w") as f:
+            self._save(f, "people")
+
+            if results_r is not None:
+                f.create_dataset("recovered", data=results_r)
+
+            if pars is not None:
+                data = pars.to_dict() if isinstance(pars, PropertySet) else pars
+                self._save_dict(data, f.create_group("pars"))
+
+    def _save(self, parent_group, name):
+        """
+        Internal method to save this LaserFrame under the given group name.
+        """
+        group = parent_group.create_group(name)
+        group.attrs["count"] = self._count
+        group.attrs["capacity"] = self._capacity
+
+        for key in dir(self):
+            if not key.startswith("_"):
+                value = getattr(self, key)
+                if isinstance(value, np.ndarray):
+                    group.create_dataset(key, data=value[: self._count])
+
+    def _save_dict(self, data, group):
+        """
+        Internal method to save a dict as datasets and attributes in a group.
+        """
+        for key, value in data.items():
+            try:
+                group.create_dataset(key, data=value)
+            except TypeError:
+                group.attrs[key] = str(value)
+
+    @classmethod
+    def load_snapshot(cls, path):
+        """
+        Load a LaserFrameIO and optional extras from an HDF5 snapshot file.
+
+        Returns:
+            frame (LaserFrameIO)
+            results_r (np.ndarray or None)
+            pars (dict or None)
+        """
+        with h5py.File(path, "r") as f:
+            group = f["people"]
+            count = int(group.attrs["count"])
+            capacity = int(group.attrs["capacity"])
+
+            frame = cls(capacity=capacity, initial_count=count)
+            for key in group:
+                data = group[key][:]
+                dtype = data.dtype
+                frame.add_scalar_property(name=key, dtype=dtype, default=0)
+                setattr(frame, key, np.zeros(capacity, dtype=dtype))
+                getattr(frame, key)[:count] = data
+
+            results_r = f["recovered"][()] if "recovered" in f else None
+            pars = {key: f["pars"][key][()] for key in f["pars"]} if "pars" in f else None
+            if "pars" in f:
+                pars.update(dict(f["pars"].attrs))
+
+        return frame, results_r, pars
 
 # Sanity checks
 

--- a/src/laser_core/laserframe.py
+++ b/src/laser_core/laserframe.py
@@ -23,9 +23,10 @@ Attributes:
     capacity (int): The maximum capacity of the frame.
 """
 
-import numpy as np
 import h5py
-#from laser_core import PropertySet
+import numpy as np
+
+# from laser_core import PropertySet
 
 
 class LaserFrame:
@@ -273,7 +274,8 @@ class LaserFrame:
             results_r: Optional 2D numpy array of recovered counts
             pars: Optional PropertySet or dict of parameters
         """
-        from laser_core.propertyset import PropertySet # to avoid circular import
+        from laser_core.propertyset import PropertySet  # to avoid circular import
+
         with h5py.File(path, "w") as f:
             self._save(f, "people")
 
@@ -335,19 +337,17 @@ class LaserFrame:
 
             if "pars" in f:
                 pars_group = f["pars"]
-                #pars = {key: pars_group[key][()] for key in pars_group}
+                # pars = {key: pars_group[key][()] for key in pars_group}
                 pars = {
                     key: (pars_group[key][()].decode() if isinstance(pars_group[key][()], bytes) else pars_group[key][()])
                     for key in pars_group
                 }
-                pars.update({
-                    key: (val.decode() if isinstance(val, bytes) else val)
-                    for key, val in pars_group.attrs.items()
-                })
+                pars.update({key: (val.decode() if isinstance(val, bytes) else val) for key, val in pars_group.attrs.items()})
             else:
                 pars = None
 
         return frame, results_r, pars
+
 
 # Sanity checks
 

--- a/tests/test_laserframe.py
+++ b/tests/test_laserframe.py
@@ -287,7 +287,7 @@ class TestLaserFrame(unittest.TestCase):
             print(f"pars_loaded={pars_loaded}")
             assert pars_loaded["intervention"] == "vaccine"
 
-            print("✓ test_save_and_load_snapshot passed.")
+            print("test_save_and_load_snapshot passed.")
 
         finally:
             Path(path).unlink()

--- a/tests/test_laserframe.py
+++ b/tests/test_laserframe.py
@@ -39,7 +39,6 @@ Usage:
 import re
 import tempfile
 import unittest
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -246,10 +245,9 @@ class TestLaserFrame(unittest.TestCase):
             _ = LaserFrame(capacity=capacity, initial_count=initial_count)
 
     def test_save_and_load_snapshot(self):
-        with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as tmp:
             path = tmp.name
 
-        try:
             # Create frame
             count = 10000
             frame = LaserFrame(capacity=100000, initial_count=count)
@@ -288,9 +286,6 @@ class TestLaserFrame(unittest.TestCase):
             assert pars_loaded["intervention"] == "vaccine"
 
             print("test_save_and_load_snapshot passed.")
-
-        finally:
-            Path(path).unlink()
 
 
 if __name__ == "__main__":

--- a/tests/test_laserframe.py
+++ b/tests/test_laserframe.py
@@ -39,6 +39,7 @@ Usage:
 import re
 import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -245,9 +246,10 @@ class TestLaserFrame(unittest.TestCase):
             _ = LaserFrame(capacity=capacity, initial_count=initial_count)
 
     def test_save_and_load_snapshot(self):
-        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
             path = tmp.name
 
+        try:
             # Create frame
             count = 10000
             frame = LaserFrame(capacity=100000, initial_count=count)
@@ -286,6 +288,8 @@ class TestLaserFrame(unittest.TestCase):
             assert pars_loaded["intervention"] == "vaccine"
 
             print("test_save_and_load_snapshot passed.")
+        finally:
+            Path(path).unlink()
 
 
 if __name__ == "__main__":

--- a/tests/test_laserframe.py
+++ b/tests/test_laserframe.py
@@ -287,7 +287,7 @@ class TestLaserFrame(unittest.TestCase):
             print(f"pars_loaded={pars_loaded}")
             assert pars_loaded["intervention"] == "vaccine"
 
-            print("✅ test_save_and_load_snapshot passed.")
+            print("✓ test_save_and_load_snapshot passed.")
 
         finally:
             Path(path).unlink()

--- a/tests/test_laserframe.py
+++ b/tests/test_laserframe.py
@@ -37,12 +37,11 @@ Usage:
 """
 
 import re
-import unittest
 import tempfile
-import os
+import unittest
+from pathlib import Path
 
 import numpy as np
-import h5py
 import pytest
 
 from laser_core import LaserFrame
@@ -247,7 +246,8 @@ class TestLaserFrame(unittest.TestCase):
             _ = LaserFrame(capacity=capacity, initial_count=initial_count)
 
     def test_save_and_load_snapshot(self):
-        path = tempfile.mktemp(suffix=".h5")
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
+            path = tmp.name
 
         try:
             # Create frame
@@ -280,16 +280,18 @@ class TestLaserFrame(unittest.TestCase):
             loaded, r_loaded, pars_loaded = frame.load_snapshot(path)
 
             assert loaded.count == frame.count
-            assert np.array_equal(loaded.age[:loaded.count], frame.age[:frame.count])
-            assert np.array_equal(loaded.status[:loaded.count], frame.status[:frame.count])
+            assert np.array_equal(loaded.age[: loaded.count], frame.age[: frame.count])
+            assert np.array_equal(loaded.status[: loaded.count], frame.status[: frame.count])
             assert np.array_equal(r_loaded, results_r)
             assert pars_loaded["r0"] == 2.5
-            print( f"pars_loaded={pars_loaded}" )
+            print(f"pars_loaded={pars_loaded}")
             assert pars_loaded["intervention"] == "vaccine"
 
             print("✅ test_save_and_load_snapshot passed.")
 
         finally:
-            os.remove(path)
+            Path(path).unlink()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
AI description is a good start.

Note that this is NOT the caching feature I implemented last year in laser-measles. That would require us to make a cache of h5 pop files available on a file share in the cluster. Which is perfectly possible but out-of-ambition-scope for this change. So this just enables the user to explicitly save and load a population. It also saves (and loads) the results.R data frame, which is strongly associated with squashing, a particular use case that might not be universally applicable. It also saves the params, which is probably OK to always do.