### PR TITLE
Fix param variable in SIR example

### DIFF
--- a/docs/example.rst
+++ b/docs/example.rst
@@ -89,8 +89,8 @@ The `IntrahostProgression` class manages recovery dynamics by updating infected 
             self.population = model.population
 
             # Seed the infection
-            num_initial_infected = int(0.01 * params.population_size)  # e.g., 1% initially infected
-            infected_indices = np.random.choice(params.population_size, size=num_initial_infected, replace=False)
+            num_initial_infected = int(0.01 * model.params.population_size)  # e.g., 1% initially infected
+            infected_indices = np.random.choice(model.params.population_size, size=num_initial_infected, replace=False)
             self.population.disease_state[infected_indices] = 1
 
             # Initialize recovery timer for initially infected individuals


### PR DESCRIPTION
Fixes a typo in `example.rst` that had `params` instead of `model.params`, leading to a failure if the `IntrahostProgression` class is defined first.