### PR TITLE
Allow NumPy integers in LaserFrame constructor

### DIFF
--- a/docs/source/laser_core.demographics.rst
+++ b/docs/source/laser_core.demographics.rst
@@ -9,29 +9,29 @@ laser\_core.demographics.kmestimator module
 
 .. automodule:: laser_core.demographics.kmestimator
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 laser\_core.demographics.pyramid module
 ---------------------------------------
 
 .. automodule:: laser_core.demographics.pyramid
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 laser\_core.demographics.spatialpops module
 -------------------------------------------
 
 .. automodule:: laser_core.demographics.spatialpops
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: laser_core.demographics
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/laser_core.rst
+++ b/docs/source/laser_core.rst
@@ -17,69 +17,69 @@ laser\_core.cli module
 
 .. automodule:: laser_core.cli
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 laser\_core.extension module
 ----------------------------
 
 .. automodule:: laser_core.extension
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 laser\_core.laserframe module
 -----------------------------
 
 .. automodule:: laser_core.laserframe
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 laser\_core.migration module
 ----------------------------
 
 .. automodule:: laser_core.migration
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 laser\_core.propertyset module
 ------------------------------
 
 .. automodule:: laser_core.propertyset
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 laser\_core.random module
 -------------------------
 
 .. automodule:: laser_core.random
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 laser\_core.sortedqueue module
 ------------------------------
 
 .. automodule:: laser_core.sortedqueue
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 laser\_core.utils module
 ------------------------
 
 .. automodule:: laser_core.utils
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: laser_core
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/src/laser_core/laserframe.py
+++ b/src/laser_core/laserframe.py
@@ -53,13 +53,13 @@ class LaserFrame:
         Returns:
             None
         """
-        if not isinstance(capacity, int) or capacity <= 0:
+        if not isinstance(capacity, (int, np.integer)) or capacity <= 0:
             raise ValueError(f"Capacity must be a positive integer, got {capacity}.")
 
         if initial_count == -1:
             initial_count = capacity
 
-        if not isinstance(initial_count, int) or initial_count < 0:
+        if not isinstance(initial_count, (int, np.integer)) or initial_count < 0:
             raise ValueError(f"Initial count must be a non-negative integer, got {initial_count}.")
 
         if initial_count > capacity:

--- a/tests/test_laserframe.py
+++ b/tests/test_laserframe.py
@@ -348,8 +348,9 @@ class TestLaserFrame(unittest.TestCase):
     def test_numpy_ints_for_capacity(self):
         for t in [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64]:
             capacity = t(min(np.iinfo(t).max // 2, 1 << 10))  # Ensure capacity is reasonable
-            _ = LaserFrame(capacity)  # just use default initial count
-        assert True
+            lf = LaserFrame(capacity)  # just use default initial count
+            assert lf.capacity == int(capacity), f"Expected capacity {int(capacity)}, got {lf.capacity}"
+            assert lf.count == int(capacity), f"Expected count {int(capacity)}, got {lf.count}"
 
         return
 
@@ -357,8 +358,9 @@ class TestLaserFrame(unittest.TestCase):
         for t in [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64]:
             capacity = int(min(np.iinfo(t).max, 1 << 10))  # Ensure capacity is reasonable
             count = t(capacity // 2)
-            _ = LaserFrame(2048, initial_count=count)
-        assert True
+            lf = LaserFrame(capacity, initial_count=count)
+            assert lf.capacity == int(capacity), f"Expected capacity {int(capacity)}, got {lf.capacity}"
+            assert lf.count == int(count), f"Expected count {int(count)}, got {lf.count}"
 
         return
 

--- a/tests/test_laserframe.py
+++ b/tests/test_laserframe.py
@@ -286,10 +286,10 @@ class TestLaserFrame(unittest.TestCase):
             assert np.array_equal(loaded.status[: loaded.count], frame.status[: frame.count])
             assert np.array_equal(r_loaded, results_r)
             assert pars_loaded["r0"] == 2.5
-            print(f"pars_loaded={pars_loaded}")
+            # print(f"pars_loaded={pars_loaded}")
             assert pars_loaded["intervention"] == "vaccine"
 
-            print("test_save_and_load_snapshot passed.")
+            # print("test_save_and_load_snapshot passed.")
         finally:
             Path(path).unlink()
 
@@ -338,12 +338,29 @@ class TestLaserFrame(unittest.TestCase):
 
                     assert excess_bytes <= max_overhead, (
                         f"Excess memory for pop={pop_size}: "
-                        f"{excess_bytes / (1024*1024):.2f} MB "
+                        f"{excess_bytes / (1024 * 1024):.2f} MB "
                         f"(capacity={loaded.capacity}, expected={expected_capacity})"
                     )
 
                 finally:
                     Path(path).unlink()
+
+    def test_numpy_ints_for_capacity(self):
+        for t in [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64]:
+            capacity = t(min(np.iinfo(t).max // 2, 1 << 10))  # Ensure capacity is reasonable
+            _ = LaserFrame(capacity)  # just use default initial count
+        assert True
+
+        return
+
+    def test_numpy_ints_for_initial_count(self):
+        for t in [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64]:
+            capacity = int(min(np.iinfo(t).max, 1 << 10))  # Ensure capacity is reasonable
+            count = t(capacity // 2)
+            _ = LaserFrame(2048, initial_count=count)
+        assert True
+
+        return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #171 

Should probably be a patch version update.