### PR TITLE
Disable fail-on-warn RTD setting for now.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 formats:
   - htmlzip


### PR DESCRIPTION
The motivation for this change is that it was necessary to make some changes to doc strings so they will render properly in a mkdocs build. This is the priority build for now, since we are releasing laser-generic as our flagship, user-facing module. laser-core will continue building in RTD under sphinx but these whitespace changes generate warnings. We don't want that to cause all our PRs to fail.