### PR TITLE
✂️ prune test matrix to 3.10 and 3.14

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -10,39 +10,15 @@ jobs:
       matrix:
         include:
           - name: 'check'
-            python: '3.11'
-            toxpython: 'python3.11'
+            python: '3.12'
+            toxpython: 'python3.12'
             tox_env: 'check'
             os: 'ubuntu-latest'
           - name: 'docs'
-            python: '3.11'
-            toxpython: 'python3.11'
+            python: '3.12'
+            toxpython: 'python3.12'
             tox_env: 'docs'
             os: 'ubuntu-latest'
-          - name: 'py39 (ubuntu/x86_64)'
-            python: '3.9'
-            toxpython: 'python3.9'
-            python_arch: 'x64'
-            tox_env: 'py39'
-            cibw_arch: 'x86_64'
-            cibw_build: false
-            os: 'ubuntu-latest'
-          - name: 'py39 (windows/AMD64)'
-            python: '3.9'
-            toxpython: 'python3.9'
-            python_arch: 'x64'
-            tox_env: 'py39'
-            cibw_arch: 'AMD64'
-            cibw_build: false
-            os: 'windows-latest'
-          - name: 'py39 (macos/arm64)'
-            python: '3.9'
-            toxpython: 'python3.9'
-            python_arch: 'arm64'
-            tox_env: 'py39'
-            cibw_arch: 'arm64'
-            cibw_build: false
-            os: 'macos-latest'
           - name: 'py310 (ubuntu/x86_64)'
             python: '3.10'
             toxpython: 'python3.10'
@@ -64,78 +40,6 @@ jobs:
             toxpython: 'python3.10'
             python_arch: 'arm64'
             tox_env: 'py310'
-            cibw_arch: 'arm64'
-            cibw_build: false
-            os: 'macos-latest'
-          - name: 'py311 (ubuntu/x86_64)'
-            python: '3.11'
-            toxpython: 'python3.11'
-            python_arch: 'x64'
-            tox_env: 'py311'
-            cibw_arch: 'x86_64'
-            cibw_build: 'cp39-manylinux_x86_64'
-            os: 'ubuntu-latest'
-          - name: 'py311 (windows/AMD64)'
-            python: '3.11'
-            toxpython: 'python3.11'
-            python_arch: 'x64'
-            tox_env: 'py311'
-            cibw_arch: 'AMD64'
-            cibw_build: 'cp39-win_amd64'
-            os: 'windows-latest'
-          - name: 'py311 (macos/arm64)'
-            python: '3.11'
-            toxpython: 'python3.11'
-            python_arch: 'arm64'
-            tox_env: 'py311'
-            cibw_arch: 'arm64'
-            cibw_build: 'cp39-macosx_arm64'
-            os: 'macos-latest'
-          - name: 'py312 (ubuntu/x86_64)'
-            python: '3.12'
-            toxpython: 'python3.12'
-            python_arch: 'x64'
-            tox_env: 'py312'
-            cibw_arch: 'x86_64'
-            cibw_build: false
-            os: 'ubuntu-latest'
-          - name: 'py312 (windows/AMD64)'
-            python: '3.12'
-            toxpython: 'python3.12'
-            python_arch: 'x64'
-            tox_env: 'py312'
-            cibw_arch: 'AMD64'
-            cibw_build: false
-            os: 'windows-latest'
-          - name: 'py312 (macos/arm64)'
-            python: '3.12'
-            toxpython: 'python3.12'
-            python_arch: 'arm64'
-            tox_env: 'py312'
-            cibw_arch: 'arm64'
-            cibw_build: false
-            os: 'macos-latest'
-          - name: 'py313 (ubuntu/x86_64)'
-            python: '3.13'
-            toxpython: 'python3.13'
-            python_arch: 'x64'
-            tox_env: 'py313'
-            cibw_arch: 'x86_64'
-            cibw_build: false
-            os: 'ubuntu-latest'
-          - name: 'py313 (windows/AMD64)'
-            python: '3.13'
-            toxpython: 'python3.13'
-            python_arch: 'x64'
-            tox_env: 'py313'
-            cibw_arch: 'AMD64'
-            cibw_build: false
-            os: 'windows-latest'
-          - name: 'py313 (macos/arm64)'
-            python: '3.13'
-            toxpython: 'python3.13'
-            python_arch: 'arm64'
-            tox_env: 'py313'
             cibw_arch: 'arm64'
             cibw_build: false
             os: 'macos-latest'
@@ -206,11 +110,6 @@ jobs:
         !matrix.cibw_build
       run: >
         tox -e ${{ matrix.tox_env }} -v
-    - uses: codecov/codecov-action@v3
-      if: matrix.cover
-      with:
-        verbose: true
-        flags: ${{ matrix.tox_env }}
     - name: check wheel
       if: matrix.cibw_build
       run: twine check wheelhouse/*.whl
@@ -220,11 +119,3 @@ jobs:
       with:
         name: ${{ matrix.cibw_build }}
         path: wheelhouse/*.whl
-  finish:
-    needs: test
-    if: ${{ false && always() }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: codecov/codecov-action@v5
-      with:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/ci/templates/.github/workflows/github-actions.yml
+++ b/ci/templates/.github/workflows/github-actions.yml
@@ -10,13 +10,13 @@ jobs:
       matrix:
         include:
           - name: 'check'
-            python: '3.11'
-            toxpython: 'python3.11'
+            python: '3.12'
+            toxpython: 'python3.12'
             tox_env: 'check'
             os: 'ubuntu-latest'
           - name: 'docs'
-            python: '3.11'
-            toxpython: 'python3.11'
+            python: '3.12'
+            toxpython: 'python3.12'
             tox_env: 'docs'
             os: 'ubuntu-latest'
 {% for env in tox_environments %}

--- a/tox.ini
+++ b/tox.ini
@@ -14,17 +14,13 @@ envlist =
     clean,
     check,
     docs,
-    {py39,py310,py311,py312,py313,py314},
+    {py310,py314},
     report
 ignore_basepython_conflict = true
 
 [testenv]
 basepython =
-    py39: {env:TOXPYTHON:python3.9}
     py310: {env:TOXPYTHON:python3.10}
-    py311: {env:TOXPYTHON:python3.11}
-    py312: {env:TOXPYTHON:python3.12}
-    py313: {env:TOXPYTHON:python3.13}
     py314: {env:TOXPYTHON:python3.14}
     {bootstrap,clean,check,report,docs,codecov}: {env:TOXPYTHON:python3.12}
 setenv =


### PR DESCRIPTION
3.10 == oldest supported Python version
3.14 == newest released and supported version
Use "Goldilocks" version (not too old, not too new) 3.12 for tooling.