### PR TITLE
Remove extra args parameter in kmestimator

### DIFF
--- a/src/laser/core/demographics/kmestimator.py
+++ b/src/laser/core/demographics/kmestimator.py
@@ -183,19 +183,8 @@ class KaplanMeierEstimator:
 # Separately, consider two versions of this function, one returning uint8 (for use in
 # predict_year_of_death) and the other uint16 (for use in predict_age_at_death).
 @nb.njit(
-    [
-        (nb.int8[:], nb.uint32[:], nb.uint32),
-        (nb.int16[:], nb.uint32[:], nb.uint32),
-        (nb.int32[:], nb.uint32[:], nb.uint32),
-        (nb.int64[:], nb.uint32[:], nb.uint32),
-        (nb.uint8[:], nb.uint32[:], nb.uint32),
-        (nb.uint16[:], nb.uint32[:], nb.uint32),
-        (nb.uint32[:], nb.uint32[:], nb.uint32),
-        (nb.uint64[:], nb.uint32[:], nb.uint32),
-        (nb.float32[:], nb.uint32[:], nb.uint32),
-        (nb.float64[:], nb.uint32[:], nb.uint32),
-    ],
     parallel=True,
+    cache=True
 )
 def _pyod(ages_years: np.ndarray, cumulative_deaths: np.ndarray, max_year: np.uint32 = 100):  # pragma: no cover
     """
@@ -230,17 +219,8 @@ def _pyod(ages_years: np.ndarray, cumulative_deaths: np.ndarray, max_year: np.ui
 
 
 @nb.njit(
-    [
-        (nb.int16[:], nb.uint16[:], nb.int16[:]),
-        (nb.int32[:], nb.uint16[:], nb.int32[:]),
-        (nb.int64[:], nb.uint16[:], nb.int64[:]),
-        (nb.uint16[:], nb.uint16[:], nb.uint16[:]),
-        (nb.uint32[:], nb.uint16[:], nb.uint32[:]),
-        (nb.uint64[:], nb.uint16[:], nb.uint64[:]),
-        (nb.float32[:], nb.uint16[:], nb.float32[:]),
-        (nb.float64[:], nb.uint16[:], nb.float64[:]),
-    ],
     parallel=True,
+    cache=True
 )
 def _pdod(age_in_days: np.ndarray, year_of_death: np.ndarray, day_of_death: np.ndarray):  # pragma: no cover
     n = age_in_days.shape[0]

--- a/src/laser/core/demographics/kmestimator.py
+++ b/src/laser/core/demographics/kmestimator.py
@@ -178,14 +178,7 @@ class KaplanMeierEstimator:
         return age_at_death
 
 
-# Technically, we shouldn't allow any signed inputs because what would a negative age mean?
-# int8 is the most limited, but 127 is enough for a reasonable maximum age in years.
-# Separately, consider two versions of this function, one returning uint8 (for use in
-# predict_year_of_death) and the other uint16 (for use in predict_age_at_death).
-@nb.njit(
-    parallel=True,
-    cache=True
-)
+@nb.njit(parallel=True, cache=True)
 def _pyod(ages_years: np.ndarray, cumulative_deaths: np.ndarray, max_year: np.uint32 = 100):  # pragma: no cover
     """
     Calculate the predicted year of death based on the given ages in years.
@@ -218,10 +211,7 @@ def _pyod(ages_years: np.ndarray, cumulative_deaths: np.ndarray, max_year: np.ui
     return ysod
 
 
-@nb.njit(
-    parallel=True,
-    cache=True
-)
+@nb.njit(parallel=True, cache=True)
 def _pdod(age_in_days: np.ndarray, year_of_death: np.ndarray, day_of_death: np.ndarray):  # pragma: no cover
     n = age_in_days.shape[0]
     for i in nb.prange(n):


### PR DESCRIPTION
for faster import of laser.core

```sh
time python3 -c "import laser.core as lc; print(lc.__version__); from laser.core.demographics import KaplanMeierEstimator"
```

Before\* \*\*:

| invocation | timing |
|:-:|:-|
| 1st | 19.187s real<br>13.431s user<br>0.730s sys |
| 2nd | 10.485s real<br>9.696s user<br>0.437s sys |
| 3rd | 10.335s real<br>9.541s user<br>0.457s sys |

After\* \*\*:

| invocation | timing |
|:-:|:-|
| 1st | 7.511s real<br>3.882s user<br>0.406s sys |
| 2nd | 1.578s real<br>1.239s user<br>0.192s sys |
| 3rd | 1.539s real<br>1.290s user<br>0.173s sys |

\* 1st invocation is fresh virtual environment, includes `__pycache__` creation
\*\* Tested on GitHub Codespace

fixes #390 