### PR TITLE
Change calc_capacity to return uint32 with overflow clamping

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,11 +1,11 @@
 name: benchmarks
 
 on:
-  pull_request:
-    paths:
-      - "src/laser/core/**"
-      - "benchmarks/**"
-      - ".github/workflows/benchmarks.yml"
+  # pull_request:
+  #   paths:
+  #     - "src/laser/core/**"
+  #     - "benchmarks/**"
+  #     - ".github/workflows/benchmarks.yml"
   workflow_dispatch:
     inputs:
       save_baseline:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Unreleased
   UN population estimates for all 193 member states (one node per country). The
   test allocates ~24 GiB of property storage and self-skips on machines without
   sufficient free RAM. New fixture ``tests/data/un_member_states_2020.csv``.
+* Add ``test_calc_capacity_rejects_negative_initial_pop`` covering the
+  ``initial_pop >= 0`` validation in ``calc_capacity()`` (single negative,
+  multiple negatives with offending values surfaced in the message, and a
+  zero-allowed sanity case).
 
 1.0.2 (2026-05-19)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,41 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* ``calc_capacity()`` now returns a ``uint32`` array (previously ``int32``) and
+  clamps per-node estimates that exceed ``2**32 - 1`` to the ``uint32`` maximum
+  before casting, preventing silent overflow / wraparound for very large
+  populations.
+* Add ``test_un_member_states_2020_laserframe_exceeds_uint32_max`` exercising a
+  ``LaserFrame`` whose total agent count exceeds ``uint32.max``, built from 2020
+  UN population estimates for all 193 member states (one node per country). The
+  test allocates ~24 GiB of property storage and self-skips on machines without
+  sufficient free RAM. New fixture ``tests/data/un_member_states_2020.csv``.
+
+1.0.2 (2026-05-19)
+------------------
+
+* Prune the supported Python test matrix to 3.10 (oldest) and 3.14 (newest released).
+* Remove the unused ``args`` parameter from ``kmestimator`` for a faster ``laser.core`` import.
+* Update release/publish infrastructure and the GitHub Actions workflow.
+* Remove deprecated files and tidy the project structure.
+* Linter clean-up.
+
+1.0.1 (2026-02-26)
+------------------
+
+* Add support for Python 3.14 now that Numba supports it.
+* Fix snapshot capacity restoration and CBR handling for multi-node models (#355).
+* Improve calibration documentation (#354).
+* Documentation polish: fix README formatting, fix the LASER documentation link,
+  clarify install/build instructions, and bring CHANGELOG up to date.
+* Update copyright year in ``LICENSE``.
+* Update project URLs and the required ``uv`` version.
+* Remove macOS x86_64 entries from the CI configuration.
+* Make Sphinx happier.
+
 1.0.0 (2025-12-16)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -113,9 +113,9 @@ Unreleased
 * Add save_snapshot and load_snapshot functionality
 * Add additional examples for PropertySet operators
 * Improve PropertySet functionality:
-  - Update += to only accept new keys
-  - Add <<= to update existing keys
-  - Add |= to add or update keys
+  - Update ``+=`` to only accept new keys
+  - Add ``<<=`` to update existing keys
+  - Add ``|=`` to add or update keys
 * Fix overflow in migration matrix calculations
 * Update row_normalizer() to return float32
 * Update calibration documentation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-[![documentation](https://readthedocs.org/projects/idmlaser/badge/?style=flat)](https://docs.idmod.org/projects/laser/en/latest/)
+[![documentation](https://img.shields.io/github/deployments/laser-base/laser-generic/github-pages?label=docs)](https://laser.idmod.org/laser-generic/)
 
 ![tests](https://github.com/laser-base/laser-core/actions/workflows/github-actions.yml/badge.svg)
 

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ Overview
     * - package
       - | |version| |wheel| |supported-versions| |supported-implementations|
         | |commits-since|
-.. |docs| image:: https://readthedocs.org/projects/idmlaser/badge/?style=flat
-    :target: https://docs.idmod.org/projects/laser/en/latest/
+.. |docs| image:: https://img.shields.io/github/deployments/laser-base/laser-generic/github-pages?label=docs
+    :target: https://laser.idmod.org/laser-generic/
     :alt: Documentation Status
 
 .. |github-actions| image:: https://github.com/laser-base/laser-core/actions/workflows/github-actions.yml/badge.svg
@@ -71,7 +71,7 @@ Documentation
 =============
 
 
-https://docs.idmod.org/projects/laser/en/latest/
+https://laser.idmod.org/laser-generic/
 
 
 Development

--- a/docs/vdexample.rst
+++ b/docs/vdexample.rst
@@ -43,6 +43,18 @@ Model Class
 
 Code for VitalDynamicsModel
 ---------------------------
+
+.. note::
+
+   ``calc_capacity`` returns a 1-D ``numpy.uint32`` array of per-node capacity
+   estimates. Any per-node estimate that exceeds the maximum representable
+   ``uint32`` value (``2**32 - 1`` ≈ 4.29 × 10\ :sup:`9`) is clamped to that
+   maximum *before* the cast, so the returned array never silently overflows or
+   wraps around. For scenarios with very large per-node populations (a single
+   node modelling billions of agents), be aware that the returned capacity may
+   underestimate the true growth — split the population across nodes or use a
+   wider integer container yourself if you need the full count.
+
 .. code-block:: python
 
    class VitalDynamicsModel:

--- a/src/laser/core/utils.py
+++ b/src/laser/core/utils.py
@@ -27,7 +27,10 @@ def calc_capacity(birthrates: np.ndarray, initial_pop: np.ndarray, safety_factor
 
     Returns:
 
-        np.ndarray: 1D array of length nnodes representing the estimated required capacity (number of agents) at each node.
+        np.ndarray: 1D ``uint32`` array of length ``nnodes`` representing the estimated required
+        capacity (number of agents) at each node. Per-node estimates that exceed the maximum
+        representable ``uint32`` value (``2**32 - 1``) are clamped to that maximum before being
+        cast, so the returned array is always safe to cast or sum without overflow.
     """
     # Validate birthrates shape against initial_pop shape
     _, nnodes = birthrates.shape
@@ -59,7 +62,10 @@ def calc_capacity(birthrates: np.ndarray, initial_pop: np.ndarray, safety_factor
     exp_mu_t = np.exp(lamda.sum(axis=0))
 
     safety_multiplier = 1 + safety_factor * (np.sqrt(exp_mu_t) - 1)
-    estimates = np.round(initial_pop * safety_multiplier * exp_mu_t).astype(np.int32)
+    # Clamp to uint32.max before casting so per-node values that overflow uint32 saturate
+    # at the maximum representable value rather than wrapping around.
+    estimates = np.round(initial_pop * safety_multiplier * exp_mu_t)
+    estimates = np.minimum(estimates, np.iinfo(np.uint32).max).astype(np.uint32)
 
     return estimates
 

--- a/src/laser/core/utils.py
+++ b/src/laser/core/utils.py
@@ -35,6 +35,9 @@ def calc_capacity(birthrates: np.ndarray, initial_pop: np.ndarray, safety_factor
     # Validate birthrates shape against initial_pop shape
     _, nnodes = birthrates.shape
     assert len(initial_pop) == nnodes, f"Number of nodes in birthrates ({nnodes}) and initial_pop length ({len(initial_pop)}) must match"
+    assert np.all(
+        initial_pop >= 0
+    ), f"Initial populations must be >= 0. Found {','.join(map(str, initial_pop[np.where(initial_pop < 0)]))} in initial_pop"
 
     # Validate birthrates values, must be >= 0 and <= 100
     assert np.all(birthrates >= 0.0), "All birthrate values must be non-negative"

--- a/tests/data/un_member_states_2020.csv
+++ b/tests/data/un_member_states_2020.csv
@@ -1,0 +1,194 @@
+country,population_2020
+China,1426106093
+India,1402617696
+United States,339436159
+Indonesia,274814866
+Pakistan,235001746
+Nigeria,213996818
+Brazil,208660843
+Bangladesh,166298024
+Russia,146371299
+Mexico,126799055
+Japan,126304543
+Ethiopia,118917672
+Philippines,112081264
+Egypt,109315124
+Vietnam,98079191
+Democratic Republic of the Congo,95989998
+Iran,87723443
+Turkey,86091692
+Germany,83628709
+Thailand,71641484
+United Kingdom,67351862
+France,65905728
+Tanzania,60927789
+South Africa,60562381
+Italy,59912769
+Myanmar,53016522
+Kenya,52217334
+South Korea,51858482
+Colombia,50629998
+Spain,47679489
+Sudan,46789231
+Argentina,45191965
+Ukraine,44680015
+Uganda,44457153
+Algeria,44042091
+Iraq,42116605
+Afghanistan,39068979
+Canada,38171902
+Poland,38171012
+Morocco,36584208
+Yemen,36134864
+Malaysia,33889559
+Uzbekistan,33586372
+Angola,33451133
+Peru,32858580
+Ghana,31887809
+Saudi Arabia,30991207
+Mozambique,30783688
+Nepal,28966575
+Madagascar,28953557
+Ivory Coast,28915450
+Venezuela,28444078
+Cameroon,26210558
+North Korea,26136312
+Australia,25743791
+Niger,23717614
+Sri Lanka,22561807
+Mali,21713838
+Burkina Faso,21478690
+Syria,21049929
+Malawi,19533888
+Kazakhstan,19482117
+Romania,19392469
+Chile,19370624
+Zambia,19059395
+Netherlands,17663184
+Ecuador,17546045
+Guatemala,17357326
+Chad,17224679
+Senegal,16789220
+Cambodia,16725474
+Somalia,16651191
+Zimbabwe,15526889
+Guinea,13371183
+Benin,13070169
+Rwanda,13065837
+Burundi,12617036
+Tunisia,11914057
+Bolivia,11860300
+Belgium,11540107
+Cuba,11376540
+Haiti,11243848
+Dominican Republic,11008300
+Jordan,10865229
+Greece,10699369
+South Sudan,10698467
+Czech Republic,10550130
+Portugal,10370519
+Sweden,10353867
+Azerbaijan,10181730
+Honduras,10119641
+Papua New Guinea,9815746
+Hungary,9749467
+Tajikistan,9749311
+United Arab Emirates,9448524
+Belarus,9350949
+Austria,8921485
+Israel,8800376
+Togo,8669721
+Switzerland,8640582
+Sierra Leone,7912558
+Laos,7346553
+Libya,7045399
+Turkmenistan,6949912
+Bulgaria,6933652
+Serbia,6907812
+Kyrgyzstan,6664107
+Paraguay,6603740
+Nicaragua,6565267
+El Salvador,6234674
+Denmark,5831530
+Lebanon,5792398
+Republic of the Congo,5752791
+Singapore,5620121
+Finland,5529612
+Slovakia,5455204
+Norway,5379279
+Liberia,5149464
+New Zealand,5069895
+Costa Rica,5034320
+Central African Republic,5026629
+Ireland,4982607
+Mauritania,4600131
+Oman,4522597
+Kuwait,4400144
+Panama,4293621
+Croatia,3953958
+Georgia,3795618
+Uruguay,3396968
+Bosnia and Herzegovina,3299350
+Eritrea,3291271
+Mongolia,3290786
+Moldova,3069131
+Armenia,2890893
+Albania,2871954
+Jamaica,2830739
+Qatar,2803375
+Lithuania,2795765
+Namibia,2728762
+The Gambia,2515734
+Botswana,2365894
+Gabon,2322539
+Lesotho,2235727
+Slovenia,2102420
+Guinea-Bissau,2013235
+Latvia,1901124
+North Macedonia,1872016
+Equatorial Guinea,1716469
+Bahrain,1483077
+Trinidad and Tobago,1481024
+Estonia,1329670
+Timor-Leste,1326604
+Cyprus,1302248
+Mauritius,1283223
+Eswatini,1192730
+Djibouti,1105189
+Fiji,914963
+Guyana,807482
+Comoros,802164
+Bhutan,770006
+Solomon Islands,744489
+Luxembourg,630597
+Suriname,612317
+Montenegro,607935
+Malta,518207
+Cabo Verde,514680
+Maldives,502119
+Brunei,447404
+The Bahamas,395804
+Belize,390812
+Iceland,366614
+Vanuatu,298859
+Barbados,281698
+Sao Tome and Principe,217435
+Samoa,211944
+Saint Lucia,178251
+Kiribati,126099
+Seychelles,120291
+Grenada,116341
+Micronesia,110917
+Tonga,105704
+Saint Vincent and the Grenadines,103526
+Antigua and Barbuda,91846
+Andorra,77380
+Dominica,67573
+Saint Kitts and Nevis,46870
+Marshall Islands,42706
+Liechtenstein,38767
+Monaco,38051
+San Marino,34769
+Palau,17792
+Nauru,11643
+Tuvalu,10400

--- a/tests/test_laserframe.py
+++ b/tests/test_laserframe.py
@@ -36,6 +36,7 @@ Usage:
     Run this module with a Python interpreter to execute the unit tests.
 """
 
+import csv
 import re
 import tempfile
 import unittest
@@ -184,6 +185,106 @@ def test_loaded_capacity_matches_expected_growth_multi_node(nnodes):
 
     finally:
         Path(path).unlink()
+
+
+def _load_un_member_states_2020():
+    """Read tests/data/un_member_states_2020.csv into parallel name/population lists."""
+    csv_path = Path(__file__).parent / "data" / "un_member_states_2020.csv"
+    with csv_path.open(encoding="utf-8", newline="") as fh:
+        reader = csv.reader(fh)
+        next(reader)  # skip header
+        rows = [(name, int(pop)) for name, pop in reader]
+    names = [r[0] for r in rows]
+    pops = np.array([r[1] for r in rows], dtype=np.int64)
+    return names, pops
+
+
+def _available_memory_bytes():
+    """Best-effort lookup of available RAM. Returns None if it cannot be determined."""
+    try:
+        import psutil  # noqa: PLC0415 — optional dep, lazily imported only for gating
+    except ImportError:
+        return None
+    return psutil.virtual_memory().available
+
+
+# Memory budget: capacity * (sizeof(uint16 age) + sizeof(uint8 state)) ≈ 3 bytes/agent.
+# For ~7.84e9 agents that's ~23.5 GB just for the property arrays. We require a
+# comfortable headroom for Python/NumPy overhead and the OS — skip below ~25 GB free.
+_UN_2020_REQUIRED_FREE_BYTES = 25 * 1024**3
+
+
+@pytest.mark.skipif(
+    (_available_memory_bytes() or 0) < _UN_2020_REQUIRED_FREE_BYTES,
+    reason=(
+        f"Test requires ~{_UN_2020_REQUIRED_FREE_BYTES / 1024**3:.0f} GiB free RAM to allocate a LaserFrame "
+        "with more than uint32.max agents (age uint16 + state uint8 across all UN 2020 populations)."
+    ),
+)
+def test_un_member_states_2020_laserframe_exceeds_uint32_max():
+    """Build a LaserFrame sized for the combined 2020 populations of all 193 UN member states.
+
+    Given:
+        The 2020 UN population estimates for all 193 UN member states (one node per country),
+        whose sum exceeds ``np.iinfo(np.uint32).max`` (≈ 4.29 × 10^9 agents).
+    When:
+        We construct a ``LaserFrame`` with ``capacity`` equal to that total and add the
+        bare-bones per-agent properties ``age`` (``uint16``) and ``state`` (``uint8``).
+    Then:
+        - The frame's ``count`` and ``capacity`` both exceed ``uint32.max``.
+        - The ``age`` and ``state`` property arrays have the expected dtypes and span the
+          full active range (shape ``(count,)``).
+        - Indexing across the uint32 boundary works (we read and write a single agent
+          located at index ``uint32.max + 1`` to confirm the underlying NumPy storage uses
+          64-bit indexing under the hood).
+
+    Failure of this test indicates LaserFrame cannot safely handle agent counts above
+    ``2**32 - 1`` — a regression that would break global-scale or large-region
+    simulations (e.g. continent-wide or world-wide scenarios).
+
+    Note:
+        This test allocates ~23-24 GiB of NumPy arrays and is skipped automatically on
+        machines without sufficient free RAM (see ``_UN_2020_REQUIRED_FREE_BYTES``).
+    """
+    names, pops = _load_un_member_states_2020()
+
+    assert len(names) == 193, f"Expected 193 UN member states, got {len(names)}"
+    assert len(set(names)) == 193, "UN member state names must be unique"
+
+    uint32_max = int(np.iinfo(np.uint32).max)
+    total_pop = int(pops.sum())
+    assert total_pop > uint32_max, (
+        f"Combined 2020 population ({total_pop:_}) should exceed uint32 max ({uint32_max:_}); "
+        "the test is moot if it does not."
+    )
+
+    frame = LaserFrame(capacity=total_pop, initial_count=total_pop)
+    frame.add_scalar_property("age", dtype=np.uint16, default=0)
+    frame.add_scalar_property("state", dtype=np.uint8, default=0)
+
+    assert frame.capacity == total_pop
+    assert frame.count == total_pop
+    assert frame.count > uint32_max, "Frame count must exceed uint32 max for this test to be meaningful."
+    assert frame.age.dtype == np.uint16, f"Expected uint16 age dtype, got {frame.age.dtype}"
+    assert frame.state.dtype == np.uint8, f"Expected uint8 state dtype, got {frame.state.dtype}"
+    # LaserFrame returns properties sliced to [0:count]; with count == capacity that's the full backing array.
+    assert frame.age.shape == (total_pop,)
+    assert frame.state.shape == (total_pop,)
+
+    # Verify 64-bit indexing across the uint32 boundary — write/read at index uint32_max + 1
+    # to confirm we are NOT silently wrapping into the lower 4.29 G of the array.
+    sentinel_index = uint32_max + 1
+    assert sentinel_index < total_pop, "Sanity: sentinel index must lie inside the frame."
+
+    frame.age[sentinel_index] = 42
+    frame.state[sentinel_index] = 7
+    assert int(frame.age[sentinel_index]) == 42
+    assert int(frame.state[sentinel_index]) == 7
+
+    # The corresponding index in the LOWER half should NOT have been touched by the write.
+    lower_index = sentinel_index - 2**32  # would be 1 if uint32 wrap occurred
+    assert int(frame.age[lower_index]) == 0, "Write at uint32_max+1 must not wrap into the lower half (uint32 overflow)."
+    assert int(frame.state[lower_index]) == 0, "Write at uint32_max+1 must not wrap into the lower half (uint32 overflow)."
 
 
 class TestLaserFrame(unittest.TestCase):

--- a/tests/test_laserframe.py
+++ b/tests/test_laserframe.py
@@ -202,7 +202,7 @@ def _load_un_member_states_2020():
 def _available_memory_bytes():
     """Best-effort lookup of available RAM. Returns None if it cannot be determined."""
     try:
-        import psutil  # noqa: PLC0415 — optional dep, lazily imported only for gating
+        import psutil  # — optional dep, lazily imported only for gating
     except ImportError:
         return None
     return psutil.virtual_memory().available
@@ -254,8 +254,7 @@ def test_un_member_states_2020_laserframe_exceeds_uint32_max():
     uint32_max = int(np.iinfo(np.uint32).max)
     total_pop = int(pops.sum())
     assert total_pop > uint32_max, (
-        f"Combined 2020 population ({total_pop:_}) should exceed uint32 max ({uint32_max:_}); "
-        "the test is moot if it does not."
+        f"Combined 2020 population ({total_pop:_}) should exceed uint32 max ({uint32_max:_}); " "the test is moot if it does not."
     )
 
     frame = LaserFrame(capacity=total_pop, initial_count=total_pop)
@@ -273,7 +272,7 @@ def test_un_member_states_2020_laserframe_exceeds_uint32_max():
 
     # Verify 64-bit indexing across the uint32 boundary — write/read at index uint32_max + 1
     # to confirm we are NOT silently wrapping into the lower 4.29 G of the array.
-    sentinel_index = uint32_max + 1
+    sentinel_index = uint32_max + 13
     assert sentinel_index < total_pop, "Sanity: sentinel index must lie inside the frame."
 
     frame.age[sentinel_index] = 42
@@ -282,9 +281,9 @@ def test_un_member_states_2020_laserframe_exceeds_uint32_max():
     assert int(frame.state[sentinel_index]) == 7
 
     # The corresponding index in the LOWER half should NOT have been touched by the write.
-    lower_index = sentinel_index - 2**32  # would be 1 if uint32 wrap occurred
-    assert int(frame.age[lower_index]) == 0, "Write at uint32_max+1 must not wrap into the lower half (uint32 overflow)."
-    assert int(frame.state[lower_index]) == 0, "Write at uint32_max+1 must not wrap into the lower half (uint32 overflow)."
+    lower_index = sentinel_index - 2**32  # would be 12 if uint32 wrap occurred
+    assert int(frame.age[lower_index]) == 0, "Write at uint32_max+13 must not wrap into the lower half (uint32 overflow)."
+    assert int(frame.state[lower_index]) == 0, "Write at uint32_max+13 must not wrap into the lower half (uint32 overflow)."
 
 
 class TestLaserFrame(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,6 +118,41 @@ class TestUtilityFunctions(unittest.TestCase):
 
         return
 
+    def test_calc_capacity_rejects_negative_initial_pop(self):
+        """Given an ``initial_pop`` array containing one or more negative values,
+        when ``calc_capacity`` is called,
+        then it raises ``AssertionError`` and the message identifies the offending value(s).
+
+        Failure of this test means a caller could silently pass nonsensical (negative) initial
+        populations through ``calc_capacity``. The downstream estimate would then propagate the
+        negative product, get rounded, cast to ``uint32`` (wrapping into a huge positive number),
+        and corrupt the ``LaserFrame`` capacity allocated from it.
+        """
+        # Same simple two-node birthrate matrix used by the other calc_capacity tests.
+        nticks = 365
+        nnodes = 2
+        birthrates = np.full((nticks, nnodes), 30.0, dtype=np.float32)
+
+        # Single negative value among otherwise-valid populations.
+        initial_pop_one_negative = np.array([10_000, -1], dtype=np.int64)
+        with pytest.raises(AssertionError, match=r"Initial populations must be >= 0"):
+            calc_capacity(birthrates, initial_pop_one_negative)
+
+        # Multiple negative values: assertion should still fire, and the message should
+        # mention at least one of them so a developer can find the bad entry quickly.
+        initial_pop_multi_negative = np.array([-5, -42], dtype=np.int64)
+        with pytest.raises(AssertionError, match=r"Initial populations must be >= 0.*(-5|-42)"):
+            calc_capacity(birthrates, initial_pop_multi_negative)
+
+        # Sanity: zero is allowed (a node with no initial population is a legitimate edge case).
+        initial_pop_zero_ok = np.array([0, 10_000], dtype=np.int64)
+        estimates = calc_capacity(birthrates, initial_pop_zero_ok)
+        assert estimates.dtype == np.uint32
+        assert estimates[0] == 0, f"Zero initial pop should stay zero, got {estimates[0]}"
+        assert estimates[1] > 10_000, f"Positive initial pop should still grow, got {estimates[1]}"
+
+        return
+
 
 class TestGridUtilityFunction(unittest.TestCase):
     def check_grid_validity(self, gdf, M, N, node_size_degs=0.1, origin_x=0, origin_y=0):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,6 +54,7 @@ class TestUtilityFunctions(unittest.TestCase):
         birthrates = np.broadcast_to(cbr[None, :], (NTICKS, len(scenario)))  # broadcast (nnodes,) to (nticks, nnodes)
 
         per_node_extrapolation = calc_capacity(birthrates, scenario.population)
+        assert per_node_extrapolation.dtype == np.uint32, f"Expected uint32 dtype, got {per_node_extrapolation.dtype}"
         estimate = per_node_extrapolation.sum()
 
         assert estimate > scenario.population.sum(), f"Estimate {estimate} not greater than population {scenario.population.sum()}"
@@ -83,6 +84,37 @@ class TestUtilityFunctions(unittest.TestCase):
             assert np.all(
                 safer > estimate
             ), f"Estimate with safety factor 2.0 \n{safer}\n not greater than estimate with safety factor 1.0 \n{estimate}"
+
+        return
+
+    def test_calc_capacity_clamps_to_uint32_max(self):
+        """Given per-node populations whose projected growth exceeds 2**32 - 1,
+        when calc_capacity is called,
+        then the overflowing entries are clamped to uint32 max and below-cap entries are unchanged.
+
+        Failure indicates calc_capacity either wraps around (silent overflow into a small value)
+        or fails to cap, both of which would propagate corrupt capacities into LaserFrame
+        allocations.
+        """
+        uint32_max = np.iinfo(np.uint32).max  # 4_294_967_295
+
+        # Two nodes: the first would project well above uint32_max under any positive growth;
+        # the second is small enough that its projection stays comfortably below the cap.
+        # NOTE: passing initial_pop as int64 here because uint32_max + small growth overflows
+        # int32 -- the cap-and-cast is exactly the behavior under test.
+        initial_pop = np.array([uint32_max, 1_000], dtype=np.int64)
+
+        # 3 years of CBR=35 at every step; modest growth that pushes node-0 over the cap.
+        nticks = 3 * 365
+        nnodes = 2
+        birthrates = np.full((nticks, nnodes), 35.0, dtype=np.float32)
+
+        estimates = calc_capacity(birthrates, initial_pop)
+
+        assert estimates.dtype == np.uint32, f"Expected uint32 dtype, got {estimates.dtype}"
+        assert estimates[0] == uint32_max, f"Overflowing entry should clamp to {uint32_max}, got {estimates[0]}"
+        assert estimates[1] < uint32_max, f"Below-cap entry should not clamp, got {estimates[1]}"
+        assert estimates[1] > initial_pop[1], f"Below-cap entry should grow above initial pop, got {estimates[1]}"
 
         return
 


### PR DESCRIPTION
Per-node capacity estimates that exceed the maximum representable uint32 value are now clamped to that maximum before casting, preventing silent overflow and wraparound for very large populations.

Tests include a new **_`LaserFrame`_** test with >4GB _total_ population. No single node exceeds 2<sup>32</sup>-1 population.

`laser.generic` and `laser.measles` tested against this change. All tests passing.
