### PR TITLE
🔧 🐛 prevent duplicate "main" release on bump-version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -70,6 +70,6 @@ jobs:
         run: uvx --python 3.12 bump-my-version bump ${{ github.event.inputs.version_type }}
 
       - name: Push
-        run: |
-          git push origin HEAD:refs/heads/main
-          git push origin --tags
+        # `--follow-tags` pushes the branch and any annotated tags reachable from it
+        # in a single push event, so the downstream release workflow fires exactly once.
+        run: git push --follow-tags origin HEAD:refs/heads/main

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Build on Ubuntu 📦
     runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'v')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -32,6 +33,7 @@ jobs:
       Sign Python 🐍 distribution 📦 with Sigstore and make GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'v')
     environment:
       name: restricted # remove if v* tag protection is enabled with GitHub App as sole bypass
     permissions:
@@ -80,6 +82,7 @@ jobs:
       Publish Python 🐍 distribution 📦 to PyPI
     needs: github-release
     runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'v')
     environment:
       name: restricted # remove if v* tag protection is enabled with GitHub App as sole bypass
       url: https://pypi.org/p/laser-core


### PR DESCRIPTION
The Bump Version workflow's two separate pushes (branch then --tags) allowed release-publish to fire on a non-tag ref, producing a release named "main" alongside the real vX.Y.Z one. Push branch and annotated tags atomically with --follow-tags, and gate every release-publish job on startsWith(github.ref_name, 'v') as a belt-and-braces guard.