### PR TITLE
Fix tag matching in release workflow conditions

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Build on Ubuntu 📦
     runs-on: ubuntu-latest
-    if: startsWith(github.ref_name, 'v')
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -33,7 +33,7 @@ jobs:
       Sign Python 🐍 distribution 📦 with Sigstore and make GitHub Release
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref_name, 'v')
+    if: startsWith(github.ref, 'refs/tags/v')
     environment:
       name: restricted # remove if v* tag protection is enabled with GitHub App as sole bypass
     permissions:
@@ -82,7 +82,7 @@ jobs:
       Publish Python 🐍 distribution 📦 to PyPI
     needs: github-release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref_name, 'v')
+    if: startsWith(github.ref, 'refs/tags/v')
     environment:
       name: restricted # remove if v* tag protection is enabled with GitHub App as sole bypass
       url: https://pypi.org/p/laser-core


### PR DESCRIPTION
The `github.ref_name` contains only the tag name (e.g., 'v1.0.0'), not the full ref path. However, the current conditions work correctly in practice. This change makes the conditions more explicit and consistent with the full ref format for clarity.